### PR TITLE
Changed nabtoGetFingerprint to take an unmanaged buffer as second argument

### DIFF
--- a/src/NabtoClient/Interop/IPlatformAdapter.cs
+++ b/src/NabtoClient/Interop/IPlatformAdapter.cs
@@ -65,7 +65,7 @@ namespace Nabto.Client.Interop
         NabtoStatus nabtoSetOption(string name, string value);
         //NabtoStatus nabtoLookupExistingProfile(out string email);
         NabtoStatus nabtoCreateSelfSignedProfile(string email, string password);    
-        NabtoStatus nabtoGetFingerprint(string certId, out string fingerprint);    
+        NabtoStatus nabtoGetFingerprint(string certId, out byte[] fingerprint);    
         NabtoStatus nabtoCreateProfile(string email, string password);    
         NabtoStatus nabtoSignup(string email, string password);
         NabtoStatus nabtoResetAccountPassword(string email);

--- a/src/NabtoClient/Interop/PlatformAdapter.cs
+++ b/src/NabtoClient/Interop/PlatformAdapter.cs
@@ -180,7 +180,7 @@ namespace Nabto.Client.Interop
             return NabtoStatusHandler(concretePlatformAdapter.nabtoCreateSelfSignedProfile(email, password), "nabtoCreateSelfSignedProfile");
         }
 
-        public NabtoStatus nabtoGetFingerprint(string certId, out string fingerprint) {
+        public NabtoStatus nabtoGetFingerprint(string certId, out byte[] fingerprint) {
             return NabtoStatusHandler(concretePlatformAdapter.nabtoGetFingerprint(certId, out fingerprint), "nabtoGetFingerprint");
         }
         

--- a/src/NabtoClient/Interop/Win32/Win32InteropAdapter.cs
+++ b/src/NabtoClient/Interop/Win32/Win32InteropAdapter.cs
@@ -324,18 +324,33 @@ namespace Nabto.Client.Interop.Win32
             return Win32NativeMethods.nabtoCreateSelfSignedProfile(email, password);
         }
 
-        public int nabtoGetFingerprint(string certId, out string fingerprint)
+        public int nabtoGetFingerprint(string certId, out byte[] fingerprint)
         {
-            IntPtr nativeFingerprintBuffer;
-            var status = Win32NativeMethods.nabtoGetFingerprint(certId, out nativeFingerprintBuffer);
-            if (status == NABTO_OK)
+            int status;
+            fingerprint = null;
+            IntPtr unmanagedFingerprintBuffer = IntPtr.Zero;
+
+            try
             {
-                fingerprint = MoveString(nativeFingerprintBuffer);
+                unmanagedFingerprintBuffer = Marshal.AllocHGlobal(16);
+
+                status = Win32NativeMethods.nabtoGetFingerprint(certId, unmanagedFingerprintBuffer);
+
+                if (status == NABTO_OK)
+                {
+                    fingerprint = new byte[16];
+                    Marshal.Copy(unmanagedFingerprintBuffer, fingerprint, 0, 16);
+                }
             }
-            else
+        
+            finally
             {
-                fingerprint = null;
+                if (unmanagedFingerprintBuffer != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(unmanagedFingerprintBuffer);
+                }
             }
+
             return status;
         }
 

--- a/src/NabtoClient/Interop/Win32/Win32NativeMethods.cs
+++ b/src/NabtoClient/Interop/Win32/Win32NativeMethods.cs
@@ -141,7 +141,7 @@ namespace Nabto.Client.Interop.Win32
         extern static public int nabtoCreateSelfSignedProfile(string email, string password);
 
         [DllImport("nabto_client_api", CharSet = CharSet.Ansi)]
-        extern static public int nabtoGetFingerprint(string certId, out IntPtr fingerprint);
+        extern static public int nabtoGetFingerprint(string certId, IntPtr fingerprint);
 
         [DllImport("nabto_client_api", CharSet = CharSet.Ansi)]
         extern static public int nabtoCreateProfile(string email, string password);

--- a/src/NabtoClient/Interop/Win32/Win32PlatformAdapter.cs
+++ b/src/NabtoClient/Interop/Win32/Win32PlatformAdapter.cs
@@ -204,7 +204,7 @@ namespace Nabto.Client.Interop.Win32
             return (NabtoStatus)interopAdapter.nabtoCreateSelfSignedProfile(email, password);
         }
 
-        public NabtoStatus nabtoGetFingerprint(string certId, out string fingerprint)
+        public NabtoStatus nabtoGetFingerprint(string certId, out byte[] fingerprint)
         {
             return (NabtoStatus)interopAdapter.nabtoGetFingerprint(certId, out fingerprint);
         }

--- a/src/NabtoClient/NabtoClient.cs
+++ b/src/NabtoClient/NabtoClient.cs
@@ -365,8 +365,8 @@ namespace Nabto.Client
         /// Retrieve the RSA public key fingerprint of the specified certificate.
         /// </summary>
         /// <param name="certId">The identification of the cert to be able to locate it in the cert store.</param>
-        /// <param name="password">The password associated with the account to create.</param>
-        public void GetFingerprint(string certId, out string fingerprint)
+        /// <param name="fingerprint">16 byte array containing the public key fingerprint.</param>
+        public void GetFingerprint(string certId, out byte[] fingerprint)
         {
             if (certId == null)
             {


### PR DESCRIPTION
The native implementation then fills this buffer with the relevant public key fingerprint.

This PR fixes an issue where GetFingerprint causes memory corruption, due to the second argument being an out string.

The implemetation is pretty basic.
1) allocate unmanaged buffer on the heap
2) pass it to the native code which fills it
3) copy the - now filled - unmanaged buffer to a managed ditto.
4) return the managed buffer as out argument.
5) free unmanged buffer.

@mkm85 @gammelby 